### PR TITLE
Implemented remaining methods of AmazonMusicController

### DIFF
--- a/src/lib/controllers/YouTubeMusicController.ts
+++ b/src/lib/controllers/YouTubeMusicController.ts
@@ -1,6 +1,7 @@
 import { NotReadyReason } from '~types/NotReadyReason';
 import type { PlayerState, SongInfo } from '~types/PlayerState';
 import { RepeatMode } from '~types/RepeatMode';
+import { lengthTextToSeconds } from '~util/lengthTextToSeconds';
 import { mainWorldToBackground } from '~util/mainWorldToBackground';
 import { onDocumentReady } from '~util/onDocumentReady';
 
@@ -186,18 +187,6 @@ export class YouTubeMusicController implements IController {
     return navigationRequest;
   }
 
-  private _lengthTextToSeconds(lengthText: string): number {
-    const parts = lengthText.split(':');
-
-    let duration = 0;
-
-    parts.forEach((part, index) => {
-      duration += parseInt(part) * Math.pow(60, parts.length - index - 1);
-    });
-
-    return duration;
-  }
-
   private _longBylineToArtistAlbum(longBylineRuns: { text: string }[]) {
     // The last two runs are a separator and the year, album comes before that
     const album = longBylineRuns[longBylineRuns.length - 3].text;
@@ -244,7 +233,7 @@ export class YouTubeMusicController implements IController {
     );
 
     return {
-      duration: this._lengthTextToSeconds(rendererData.lengthText.runs[0].text),
+      duration: lengthTextToSeconds(rendererData.lengthText.runs[0].text),
       trackId,
       trackName,
       artistName: artist,
@@ -257,8 +246,6 @@ export class YouTubeMusicController implements IController {
    * Forces app the capture a navigation request so we can clone it later. This
    * is necessary when the user hasn't already clicked on a song and we want to
    * take programmatic control of the page.
-   *
-   * TODO: Add screenshot "curtain" to hide the navigation
    */
   private async _forceCaptureNavigationRequest() {
     return new Promise(async (resolve) => {

--- a/src/util/lengthTextToSeconds.ts
+++ b/src/util/lengthTextToSeconds.ts
@@ -1,0 +1,11 @@
+export const lengthTextToSeconds = (lengthText: string): number => {
+  const parts = lengthText.split(':');
+
+  let duration = 0;
+
+  parts.forEach((part, index) => {
+    duration += parseInt(part) * Math.pow(60, parts.length - index - 1);
+  });
+
+  return duration;
+};

--- a/src/util/waitForElement.ts
+++ b/src/util/waitForElement.ts
@@ -1,0 +1,31 @@
+// Wait for an element to appear on the page using MutationObserver
+export const waitForElement = async (
+  selector: string,
+  timeout = 10000
+): Promise<Element> => {
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const observer = new MutationObserver((mutations, observerInstance) => {
+      const element = document.querySelector(selector);
+
+      if (element) {
+        observerInstance.disconnect();
+        resolve(element);
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+
+    const interval = setInterval(() => {
+      if (Date.now() - startTime > timeout) {
+        clearInterval(interval);
+        observer.disconnect();
+        reject(new Error(`Timeout waiting for element: ${selector}`));
+      }
+    }, 100);
+  });
+};


### PR DESCRIPTION
### Overview
Implemented the remaining methods (happy paths primarily - non-happy paths are hard to predict right now and will mostly be discovered through testing) for AmazonMusicController. This includes the following methods:

- `toggleLike` and `toggleDislike`: Unlike other methods, theres were simpler and more reliable to do with DOM interaction simulations due to the complex structure and data in the action that would otherwise be required to dispatch. Added a `waitForElement` util function because the dislike requires opening a context menu that takes time (< 50ms) to open.
- `getPlayerState`: Fairly self-explanatory
- `getQueue`: Main logic here was just getting the queue to load. By default, the queue data is not loaded unless the user opens it up. I added methods to load in the queue and check whether it was loaded. On my machine with fast internet, it takes about 0.75-1 seconds to load. Also added a method to convert the Amazon Music queue items to SynQ SongInfo structure.
- `isReady`: Checked whether the user is a premium member. If they are not, SynQ should not attempt to sync their session.