### PR TITLE
Created the IObserverEmitter interface and implemented it for Apple Music

### DIFF
--- a/src/contents/apple-music.ts
+++ b/src/contents/apple-music.ts
@@ -2,6 +2,7 @@ import type { PlasmoCSConfig } from 'plasmo';
 
 import { AppleMusicController } from '~lib/controllers/AppleMusicController';
 import { registerControllerHandler } from '~lib/message-handlers/registerControllerHandler';
+import { AppleMusicObserverEmitter } from '~lib/observer-emitters/AppleMusicObserverEmitter';
 import { onDocumentReady } from '~util/onDocumentReady';
 
 export const config: PlasmoCSConfig = {
@@ -14,7 +15,10 @@ const initialize = () => {
   console.info('SynQ: Initializing Apple Music');
 
   const controller = new AppleMusicController();
+  const observer = new AppleMusicObserverEmitter(controller);
+
   registerControllerHandler(controller);
+  observer.observe();
 };
 
 onDocumentReady(initialize);

--- a/src/lib/controllers/AppleMusicController.ts
+++ b/src/lib/controllers/AppleMusicController.ts
@@ -21,11 +21,11 @@ const REPEAT_MAP: Record<RepeatMode, number> = {
  */
 export class AppleMusicController implements IController {
   public play(): void {
-    this._player.play();
+    this.getPlayer().play();
   }
 
   public playPause(): void {
-    if (this._player.isPlaying) {
+    if (this.getPlayer().isPlaying) {
       this.pause();
     } else {
       this.play();
@@ -33,27 +33,27 @@ export class AppleMusicController implements IController {
   }
 
   public pause(): void {
-    this._player.pause();
+    this.getPlayer().pause();
   }
 
   public next(): void {
-    this._player.skipToNextItem();
+    this.getPlayer().skipToNextItem();
   }
 
   public previous(): void {
-    this._player.skipToPreviousItem();
+    this.getPlayer().skipToPreviousItem();
   }
 
   public toggleRepeatMode(): void {
-    switch (this._player.repeatMode) {
+    switch (this.getPlayer().repeatMode) {
       case 0:
-        this._player.repeatMode = 1;
+        this.getPlayer().repeatMode = 1;
         break;
       case 1:
-        this._player.repeatMode = 2;
+        this.getPlayer().repeatMode = 2;
         break;
       case 2:
-        this._player.repeatMode = 0;
+        this.getPlayer().repeatMode = 0;
         break;
     }
   }
@@ -73,11 +73,11 @@ export class AppleMusicController implements IController {
   }
 
   public setVolume(volume: number): void {
-    this._player.volume = volume / 100;
+    this.getPlayer().volume = volume / 100;
   }
 
   public seekTo(time: number): void {
-    this._player.seekToTime(time);
+    this.getPlayer().seekToTime(time);
   }
 
   /**
@@ -87,8 +87,8 @@ export class AppleMusicController implements IController {
    */
   public async startTrack(trackId: string): Promise<void> {
     // Loads the song in the player which is required to change to it.
-    await this._player.playLater({ song: trackId });
-    await this._player.changeToMediaItem(trackId);
+    await this.getPlayer().playLater({ song: trackId });
+    await this.getPlayer().changeToMediaItem(trackId);
   }
 
   public prepareForSession(): Promise<void> {
@@ -96,33 +96,33 @@ export class AppleMusicController implements IController {
   }
 
   public getPlayerState(): PlayerState | undefined {
-    if (!this._player) {
+    if (!this.getPlayer()) {
       return undefined;
     }
 
-    const nowPlayingItem = this._player.nowPlayingItem;
+    const nowPlayingItem = this.getPlayer().nowPlayingItem;
 
     if (!nowPlayingItem) {
       return undefined;
     }
 
     const repeatMode = Object.keys(REPEAT_MAP).find(
-      (key) => REPEAT_MAP[key] === this._player.repeatMode
+      (key) => REPEAT_MAP[key] === this.getPlayer().repeatMode
     ) as RepeatMode;
 
     const playerState: PlayerState = {
-      currentTime: this._player.currentPlaybackTime,
-      isPlaying: this._player.isPlaying,
+      currentTime: this.getPlayer().currentPlaybackTime,
+      isPlaying: this.getPlayer().isPlaying,
       repeatMode: repeatMode,
-      volume: this._player.volume * 100,
-      songInfo: this._mediaItemToSongInfo(this._player.nowPlayingItem)
+      volume: this.getPlayer().volume * 100,
+      songInfo: this._mediaItemToSongInfo(this.getPlayer().nowPlayingItem)
     };
 
     return playerState;
   }
 
   public getQueue(): SongInfo[] {
-    return this._player.queue._queueItems.map((queueItem: any) =>
+    return this.getPlayer().queue._queueItems.map((queueItem: any) =>
       this._mediaItemToSongInfo(queueItem.item)
     );
   }
@@ -136,7 +136,7 @@ export class AppleMusicController implements IController {
   }
 
   private async _isPremiumUser(): Promise<boolean> {
-    const me = await this._player.me();
+    const me = await this.getPlayer().me();
     return me.subscription.active;
   }
 
@@ -153,7 +153,7 @@ export class AppleMusicController implements IController {
     };
   }
 
-  private get _player() {
+  public getPlayer() {
     return (window as any).MusicKit.getInstance();
   }
 }

--- a/src/lib/observer-emitters/AppleMusicObserverEmitter.ts
+++ b/src/lib/observer-emitters/AppleMusicObserverEmitter.ts
@@ -1,0 +1,121 @@
+import type { AppleMusicController } from '~lib/controllers/AppleMusicController';
+import { mainWorldToBackground } from '~util/mainWorldToBackground';
+
+import type { IObserverEmitter } from './IObserverEmitter';
+
+const playbackStateChangedEvents = [
+  'playbackStateDidChange',
+  'playbackTimeDidChange',
+  'playbackDurationDidChange',
+  'playbackProgressDidChange',
+  'playbackVolumeDidChange',
+  'repeatModeDidChange'
+];
+
+export class AppleMusicObserverEmitter implements IObserverEmitter {
+  private _controller: AppleMusicController;
+  private _nowPlayingItemDidChangeHandler: () => void;
+  private _playbackStateChangeHandler: () => void;
+  private _queueItemsDidChangeHandler: () => void;
+
+  constructor(controller: AppleMusicController) {
+    this._controller = controller;
+  }
+
+  public observe(): void {
+    const interval = setInterval(() => {
+      if (this._controller.getPlayer()) {
+        console.log('SynQ: Observing player');
+        clearInterval(interval);
+
+        /**
+         * Create the handlers here so that we can remove it later.
+         * Needs to be wrapped this way so that we can use `this`.
+         */
+        this._nowPlayingItemDidChangeHandler = async () => {
+          await this._sendSongInfoUpdatedMessage();
+        };
+
+        this._playbackStateChangeHandler = async () => {
+          await this._sendPlaybackUpdatedMessage();
+        };
+
+        this._queueItemsDidChangeHandler = async () => {
+          await this._sendQueueUpdatedMessage();
+        };
+
+        /**
+         * Add the event listeners.
+         */
+        this._controller
+          .getPlayer()
+          .addEventListener(
+            'nowPlayingItemDidChange',
+            this._nowPlayingItemDidChangeHandler
+          );
+
+        playbackStateChangedEvents.forEach((event) => {
+          this._controller
+            .getPlayer()
+            .addEventListener(event, this._playbackStateChangeHandler);
+        });
+
+        this._controller
+          .getPlayer()
+          .addEventListener(
+            'queueItemsDidChange',
+            this._queueItemsDidChangeHandler
+          );
+      }
+    }, 500);
+  }
+
+  public unobserve(): void {
+    this._controller
+      .getPlayer()
+      .removeEventListener(
+        'nowPlayingItemDidChange',
+        this._nowPlayingItemDidChangeHandler
+      );
+
+    playbackStateChangedEvents.forEach((event) => {
+      this._controller
+        .getPlayer()
+        .removeEventListener(event, this._playbackStateChangeHandler);
+    });
+
+    this._controller
+      .getPlayer()
+      .removeEventListener(
+        'queueItemsDidChange',
+        this._queueItemsDidChangeHandler
+      );
+  }
+
+  private async _sendSongInfoUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'SONG_INFO_UPDATED',
+      body: {
+        songInfo: this._controller.getPlayerState().songInfo
+      }
+    });
+  }
+
+  private async _sendPlaybackUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'PLAYBACK_UPDATED',
+      body: {
+        playback: this._controller.getPlayerState()
+      }
+    });
+  }
+
+  private async _sendQueueUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'QUEUE_UPDATED',
+      body: {
+        queue: this._controller.getQueue()
+      }
+    });
+  }
+}

--- a/src/lib/observer-emitters/IObserverEmitter.ts
+++ b/src/lib/observer-emitters/IObserverEmitter.ts
@@ -1,0 +1,17 @@
+import type { IController } from '~lib/controllers/IController';
+
+/**
+ * Observer emitters are responsible for observing the state of the music player
+ * and emitting events when the state changes.
+ */
+export interface IObserverEmitter {
+  /**
+   * Begin observing the music player and emitting events when the state changes.
+   */
+  observe(): void;
+
+  /**
+   * Stop observing the music player. Remove all listeners.
+   */
+  unobserve(): void;
+}

--- a/src/lib/observers/IObserver.ts
+++ b/src/lib/observers/IObserver.ts
@@ -1,5 +1,0 @@
-/**
- * Observers are used to listen to changes in the state of each music player.
- *
- * TODO: Define the interface for observers.
- */

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -4,10 +4,9 @@ import styled from 'styled-components';
 
 import './index.css';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ControllerMessageType } from '~types/ControllerMessageType';
-import { RepeatMode } from '~types/RepeatMode';
 import { getMusicServiceTab } from '~util/tabs';
 
 const Container = styled.div`
@@ -140,6 +139,13 @@ const Popup = () => {
       }
     }).then(console.info);
   };
+
+  useEffect(() => {
+    chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
+      console.info('Received message from background', message);
+      sendResponse(undefined);
+    });
+  });
 
   return (
     <Container>

--- a/src/types/Events.ts
+++ b/src/types/Events.ts
@@ -1,0 +1,13 @@
+import type { PlayerState, SongInfo } from './PlayerState';
+
+export interface SongInfoUpdatedEventBody {
+  songInfo: SongInfo;
+}
+
+export interface PlaybackUpdatedEventBody {
+  playbackState: Omit<PlayerState, 'songInfo'>;
+}
+
+export interface QueueUpdatedEventBody {
+  queue: SongInfo[];
+}


### PR DESCRIPTION
Created a new interface called IObserverEmitter. It's a basic interface whose implementations are responsible for observing changes to their respective music service and emitting events needed by the SynQ mini controller for it to display the current state of the music service. The interface simply contains an `observe` method for starting the monitoring of changes and an `unobserve` method for cleaning up any listeners.

Then, I implemented this interface for Apple Music. MusicKit has a built-in event system for their player, making it relatively easy to react to changes. I was able to hook into that system and use the existing controller for Apple Music to get the current state in the object shapes we need and package it into an event to send to the SynQ mini controller.