### PR TITLE
Implement YouTubeMusicObserverEmitter

### DIFF
--- a/src/background/messages/PLAYBACK_UPDATED.ts
+++ b/src/background/messages/PLAYBACK_UPDATED.ts
@@ -1,0 +1,9 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+/**
+ * No-op. This file just defines the message for Plasmo. Background script
+ * does not need to do anything when this message is received.
+ */
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+
+export default handler;

--- a/src/background/messages/QUEUE_UPDATED.ts
+++ b/src/background/messages/QUEUE_UPDATED.ts
@@ -1,0 +1,9 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+/**
+ * No-op. This file just defines the message for Plasmo. Background script
+ * does not need to do anything when this message is received.
+ */
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+
+export default handler;

--- a/src/background/messages/SONG_INFO_UPDATED.ts
+++ b/src/background/messages/SONG_INFO_UPDATED.ts
@@ -1,0 +1,9 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+/**
+ * No-op. This file just defines the message for Plasmo. Background script
+ * does not need to do anything when this message is received.
+ */
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+
+export default handler;

--- a/src/contents/youtube-music.ts
+++ b/src/contents/youtube-music.ts
@@ -2,6 +2,7 @@ import type { PlasmoCSConfig } from 'plasmo';
 
 import { YouTubeMusicController } from '~lib/controllers/YouTubeMusicController';
 import { registerControllerHandler } from '~lib/message-handlers/registerControllerHandler';
+import { YouTubeMusicObserverEmitter } from '~lib/observer-emitters/YouTubeMusicObserverEmitter';
 import { onDocumentReady } from '~util/onDocumentReady';
 
 export const config: PlasmoCSConfig = {
@@ -14,7 +15,10 @@ const initialize = () => {
   console.info('SynQ: Initializing YouTube Music');
 
   const controller = new YouTubeMusicController();
+  const observer = new YouTubeMusicObserverEmitter(controller);
+
   registerControllerHandler(controller);
+  observer.observe();
 };
 
 onDocumentReady(initialize);

--- a/src/lib/controllers/YouTubeMusicController.ts
+++ b/src/lib/controllers/YouTubeMusicController.ts
@@ -55,11 +55,11 @@ export class YouTubeMusicController implements IController {
   }
 
   public play(): void {
-    this._player.playVideo();
+    this.getPlayer().playVideo();
   }
 
   public playPause(): void {
-    if (this._player.getPlayerState() === YouTubeMusicPlayerState.PLAYING) {
+    if (this.getPlayer().getPlayerState() === YouTubeMusicPlayerState.PLAYING) {
       this.pause();
     } else {
       this.play();
@@ -67,15 +67,15 @@ export class YouTubeMusicController implements IController {
   }
 
   public pause(): void {
-    this._player.pauseVideo();
+    this.getPlayer().pauseVideo();
   }
 
   public next(): void {
-    this._player.nextVideo();
+    this.getPlayer().nextVideo();
   }
 
   public previous(): void {
-    this._player.previousVideo();
+    this.getPlayer().previousVideo();
   }
 
   public toggleRepeatMode(): void {
@@ -101,11 +101,11 @@ export class YouTubeMusicController implements IController {
   }
 
   public setVolume(volume: number): void {
-    this._player.setVolume(volume);
+    this.getPlayer().setVolume(volume);
   }
 
   public seekTo(time: number): void {
-    this._player.seekTo(time);
+    this.getPlayer().seekTo(time);
   }
 
   /**
@@ -141,10 +141,10 @@ export class YouTubeMusicController implements IController {
     const songInfo: SongInfo = this._queueItemToSongInfo(queueItem);
 
     return {
-      currentTime: Math.round(this._player.getCurrentTime()),
+      currentTime: Math.round(this.getPlayer().getCurrentTime()),
       isPlaying:
-        this._player.getPlayerState() === YouTubeMusicPlayerState.PLAYING,
-      volume: this._player.getVolume(),
+        this.getPlayer().getPlayerState() === YouTubeMusicPlayerState.PLAYING,
+      volume: this.getPlayer().getVolume(),
       repeatMode: RepeatMode.NO_REPEAT,
       songInfo
     };
@@ -340,7 +340,7 @@ export class YouTubeMusicController implements IController {
 
   private _addCurtainStyles() {
     const curtainStyle = document.createElement('style');
-    curtainStyle.innerHTML = `
+    curtainStyle.innerText = `
 @keyframes spin {
   0% {
     transform: translate(-50%, -50%) rotate(0deg);
@@ -385,7 +385,7 @@ export class YouTubeMusicController implements IController {
     document.head.appendChild(curtainStyle);
   }
 
-  private get _player() {
+  public getPlayer() {
     return document.getElementById('movie_player') as any;
   }
 

--- a/src/lib/observer-emitters/YouTubeMusicObserverEmitter.ts
+++ b/src/lib/observer-emitters/YouTubeMusicObserverEmitter.ts
@@ -1,0 +1,147 @@
+import type { YouTubeMusicController } from '~lib/controllers/YouTubeMusicController';
+import { mainWorldToBackground } from '~util/mainWorldToBackground';
+
+import type { IObserverEmitter } from './IObserverEmitter';
+
+export class YouTubeMusicObserverEmitter implements IObserverEmitter {
+  private _controller: YouTubeMusicController;
+  private _onStateChangeHandler: () => void;
+  private _onVideoDataChangeHandler: () => void;
+  private _mutationObservers: MutationObserver[] = [];
+
+  constructor(controller: YouTubeMusicController) {
+    this._controller = controller;
+  }
+
+  public observe(): void {
+    const interval = setInterval(() => {
+      if (this._controller.getPlayer()) {
+        console.log('SynQ: Observing player');
+        clearInterval(interval);
+
+        this._setupPlayerStateObserver();
+        this._setupSongInfoObserver();
+        this._setupQueueObserver();
+      }
+    }, 500);
+  }
+
+  public unobserve(): void {
+    this._controller
+      .getPlayer()
+      .removeEventListener('onStateChange', this._onStateChangeHandler);
+
+    this._controller
+      .getPlayer()
+      .removeEventListener('videodatachange', this._onVideoDataChangeHandler);
+
+    this._mutationObservers.forEach((observer) => observer.disconnect());
+  }
+
+  private _setupPlayerStateObserver() {
+    this._onStateChangeHandler = async () => {
+      await this._sendPlaybackUpdatedMessage();
+    };
+
+    this._controller
+      .getPlayer()
+      .addEventListener('onStateChange', this._onStateChangeHandler);
+
+    const playerStateObserver = new MutationObserver(async () => {
+      await this._sendPlaybackUpdatedMessage();
+    });
+
+    const progressBarKnobElement = document.querySelector(
+      '#progress-bar #sliderKnob .slider-knob-inner'
+    );
+
+    progressBarKnobElement &&
+      playerStateObserver.observe(progressBarKnobElement, {
+        attributeFilter: ['value']
+      });
+
+    const likeButton = document.querySelector(
+      '.ytmusic-like-button-renderer.like'
+    );
+    likeButton &&
+      playerStateObserver.observe(likeButton, {
+        attributeFilter: ['aria-pressed']
+      });
+
+    const dislikeButton = document.querySelector(
+      '.ytmusic-like-button-renderer.dislike'
+    );
+    dislikeButton &&
+      playerStateObserver.observe(dislikeButton, {
+        attributeFilter: ['aria-pressed']
+      });
+
+    const volumeElement = document.getElementById('volume-slider');
+    volumeElement &&
+      playerStateObserver.observe(volumeElement, {
+        attributeFilter: ['value']
+      });
+
+    const repeatButton = document.querySelector('.repeat.ytmusic-player-bar');
+    repeatButton &&
+      playerStateObserver.observe(repeatButton, {
+        attributeFilter: ['aria-label']
+      });
+
+    this._mutationObservers.push(playerStateObserver);
+  }
+
+  private _setupSongInfoObserver() {
+    this._onVideoDataChangeHandler = async () => {
+      await this._sendSongInfoUpdatedMessage();
+    };
+
+    this._controller
+      .getPlayer()
+      .addEventListener('videodatachange', this._onVideoDataChangeHandler);
+  }
+
+  private _setupQueueObserver() {
+    const queueObserver = new MutationObserver(async () => {
+      await this._sendQueueUpdatedMessage();
+    });
+
+    const queueElement = document.querySelector(
+      '#contents.ytmusic-player-queue'
+    );
+
+    queueElement &&
+      queueObserver.observe(queueElement, {
+        childList: true
+      });
+
+    this._mutationObservers.push(queueObserver);
+  }
+
+  private async _sendSongInfoUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'SONG_INFO_UPDATED',
+      body: {
+        songInfo: this._controller.getPlayerState().songInfo
+      }
+    });
+  }
+
+  private async _sendPlaybackUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'PLAYBACK_UPDATED',
+      body: {
+        playback: this._controller.getPlayerState()
+      }
+    });
+  }
+
+  private async _sendQueueUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'QUEUE_UPDATED',
+      body: {
+        queue: this._controller.getQueue()
+      }
+    });
+  }
+}

--- a/src/util/mainWorldToBackground.ts
+++ b/src/util/mainWorldToBackground.ts
@@ -1,16 +1,13 @@
-import { generateRequestId } from './generateRequestId';
+import { sendToBackground } from '@plasmohq/messaging';
 
-interface BackgroundMessage {
-  name: any;
-  body?: any;
-}
+import { generateRequestId } from './generateRequestId';
 
 /**
  * A util function for using the message relay to send a message to the background script
  * from a MAIN world content script.
  */
-export const mainWorldToBackground = (
-  message: BackgroundMessage
+export const mainWorldToBackground: typeof sendToBackground = (
+  message
 ): Promise<any> => {
   const requestId = generateRequestId();
 


### PR DESCRIPTION
### Overview

- Implemented the `YouTubeMusicObserverEmitter`, which is responsible for watching for when the player state, current song, or queue changes so the mini player can stay up-to-date. I was able to subscribe to some changes from the player object, but other state changes like the like/dislike, volume, seek, repeat button, and queue required using HTML element `MutationObserver`s.
- Added message types to the `/background/messages` dir so Plasmo can auto-generate the message.name type and updated the `mainToBackground` util to use that auto-generated type
- Noticed a warning because we were using .innerHTML to set the style element. .innerText worked as well and didn't return any errors.