### PR TITLE
Implemented AmazonMusicObserver

### DIFF
--- a/src/background/messages/PLAYBACK_UPDATED.ts
+++ b/src/background/messages/PLAYBACK_UPDATED.ts
@@ -4,6 +4,8 @@ import type { PlasmoMessaging } from '@plasmohq/messaging';
  * No-op. This file just defines the message for Plasmo. Background script
  * does not need to do anything when this message is received.
  */
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  res.send(undefined);
+};
 
 export default handler;

--- a/src/background/messages/QUEUE_UPDATED.ts
+++ b/src/background/messages/QUEUE_UPDATED.ts
@@ -4,6 +4,8 @@ import type { PlasmoMessaging } from '@plasmohq/messaging';
  * No-op. This file just defines the message for Plasmo. Background script
  * does not need to do anything when this message is received.
  */
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  res.send(undefined);
+};
 
 export default handler;

--- a/src/background/messages/SONG_INFO_UPDATED.ts
+++ b/src/background/messages/SONG_INFO_UPDATED.ts
@@ -4,6 +4,8 @@ import type { PlasmoMessaging } from '@plasmohq/messaging';
  * No-op. This file just defines the message for Plasmo. Background script
  * does not need to do anything when this message is received.
  */
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {};
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  res.send(undefined);
+};
 
 export default handler;

--- a/src/contents/amazon-music.ts
+++ b/src/contents/amazon-music.ts
@@ -2,6 +2,7 @@ import type { PlasmoCSConfig } from 'plasmo';
 
 import { AmazonMusicController } from '~lib/controllers/AmazonMusicController';
 import { registerControllerHandler } from '~lib/message-handlers/registerControllerHandler';
+import { AmazonMusicObserverEmitter } from '~lib/observer-emitters/AmazonMusicObserverEmitter';
 import { onDocumentReady } from '~util/onDocumentReady';
 
 export const config: PlasmoCSConfig = {
@@ -14,7 +15,10 @@ const initialize = () => {
   console.info('SynQ: Initializing Amazon Music');
 
   const controller = new AmazonMusicController();
+  const observer = new AmazonMusicObserverEmitter(controller);
+
   registerControllerHandler(controller);
+  observer.observe();
 };
 
 onDocumentReady(initialize);

--- a/src/lib/controllers/IController.ts
+++ b/src/lib/controllers/IController.ts
@@ -1,7 +1,6 @@
 import type { NotReadyReason } from '~types/NotReadyReason';
 import type { PlayerState, SongInfo } from '~types/PlayerState';
-
-type ValueOrPromise<T> = T | Promise<T>;
+import type { ValueOrPromise } from '~types/Util';
 
 export interface IController {
   /**

--- a/src/lib/observer-emitters/AmazonMusicObserverEmitter.ts
+++ b/src/lib/observer-emitters/AmazonMusicObserverEmitter.ts
@@ -1,0 +1,168 @@
+import type { AmazonMusicController } from '~lib/controllers/AmazonMusicController';
+import { mainWorldToBackground } from '~util/mainWorldToBackground';
+
+import type { IObserverEmitter } from './IObserverEmitter';
+
+const playbackStateChangedEvents = [
+  'playpause',
+  'started',
+  'ended',
+  'timeupdate'
+];
+
+export class AmazonMusicObserverEmitter implements IObserverEmitter {
+  private _controller: AmazonMusicController;
+  private _onStateChangeHandler: () => void;
+  private _queueObserverInterval: NodeJS.Timer;
+  private _unsubscribeStoreObserver: () => void;
+
+  private _currentState: {
+    trackId: string;
+    queueIds: string[];
+    rating: string;
+    volume: number;
+    repeat: string;
+  };
+
+  constructor(controller: AmazonMusicController) {
+    this._controller = controller;
+    this._currentState = {
+      trackId: undefined,
+      queueIds: [],
+      rating: undefined,
+      volume: undefined,
+      repeat: undefined
+    };
+  }
+
+  public observe(): void {
+    const maestroInterval = setInterval(async () => {
+      if (await this._controller.getMaestroInstance()) {
+        console.log('SynQ: Observing player');
+        clearInterval(maestroInterval);
+
+        this._setupMaestroObserver();
+        this._setupQueueObserver();
+
+        // The store observer also requires the maestro instance to be ready,
+        // so we nest the store observer setup inside the maestro observer setup.
+        const storeInterval = setInterval(async () => {
+          if (this._controller.getStore()) {
+            console.log('SynQ: Observing store');
+            clearInterval(storeInterval);
+
+            this._setupStoreObserver();
+          }
+        }, 500);
+      }
+    }, 500);
+  }
+
+  public async unobserve(): Promise<void> {
+    const maestro = await this._controller.getMaestroInstance();
+
+    playbackStateChangedEvents.forEach((event) => {
+      maestro.removeEventListener(event, this._onStateChangeHandler);
+    });
+
+    clearInterval(this._queueObserverInterval);
+
+    this._unsubscribeStoreObserver();
+  }
+
+  /**
+   * Maestro is the Amazon Music player which has a couple basic events we can listen to
+   * for reliable playback state updates.
+   */
+  private async _setupMaestroObserver() {
+    const maestro = await this._controller.getMaestroInstance();
+
+    this._onStateChangeHandler = async () => {
+      await this._sendPlaybackUpdatedMessage();
+    };
+
+    playbackStateChangedEvents.forEach((event) => {
+      maestro.addEventListener(event, this._onStateChangeHandler);
+    });
+  }
+
+  /**
+   * For everything Maestro doesn't send events for, we can subscribe to the application
+   * state changes using the store to observe changes, including current track, ratings,
+   * and volume.
+   */
+  private async _setupStoreObserver() {
+    const store = this._controller.getStore();
+    const maestro = await this._controller.getMaestroInstance();
+
+    this._unsubscribeStoreObserver = store.subscribe(async () => {
+      const state = store.getState();
+
+      if (state.Storage?.RATINGS?.TRACK_RATING !== this._currentState.rating) {
+        this._currentState.rating = state.Storage.RATINGS.TRACK_RATING;
+        await this._sendSongInfoUpdatedMessage();
+      }
+
+      if (state.Media?.mediaId !== this._currentState.trackId) {
+        this._currentState.trackId = state.Media.mediaId;
+        await this._sendSongInfoUpdatedMessage();
+      }
+
+      if (state.PlaybackStates?.repeat?.state !== this._currentState.repeat) {
+        this._currentState.repeat = state.PlaybackStates.repeat.state;
+        await this._sendPlaybackUpdatedMessage();
+      }
+
+      if (maestro.getVolume() !== this._currentState.volume) {
+        this._currentState.volume = maestro.getVolume();
+        await this._sendPlaybackUpdatedMessage();
+      }
+    });
+  }
+
+  /**
+   * The queue is a bit special because the application state is only populated when
+   * the user opens the queue. We got around this in the controller.getQueue() method,
+   * so we can use that to force fetch the queue if it isn't available and then check
+   * when it changes.
+   */
+  private _setupQueueObserver() {
+    this._queueObserverInterval = setInterval(async () => {
+      const queue = await this._controller.getQueue();
+
+      const newQueueIds = queue.map((track) => track.trackId);
+
+      if (newQueueIds.join() !== this._currentState.queueIds.join()) {
+        this._currentState.queueIds = newQueueIds;
+        await this._sendQueueUpdatedMessage();
+      }
+    }, 2000);
+  }
+
+  private async _sendSongInfoUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'SONG_INFO_UPDATED',
+      body: {
+        songInfo: (await this._controller.getPlayerState()).songInfo
+      }
+    });
+  }
+
+  private async _sendPlaybackUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'PLAYBACK_UPDATED',
+      body: {
+        playback: await this._controller.getPlayerState()
+      }
+    });
+  }
+
+  private async _sendQueueUpdatedMessage(): Promise<void> {
+    await mainWorldToBackground({
+      name: 'QUEUE_UPDATED',
+      body: {
+        queue: await this._controller.getQueue()
+      }
+    });
+  }
+}

--- a/src/lib/observer-emitters/IObserverEmitter.ts
+++ b/src/lib/observer-emitters/IObserverEmitter.ts
@@ -1,4 +1,5 @@
 import type { IController } from '~lib/controllers/IController';
+import type { ValueOrPromise } from '~types/Util';
 
 /**
  * Observer emitters are responsible for observing the state of the music player
@@ -8,10 +9,10 @@ export interface IObserverEmitter {
   /**
    * Begin observing the music player and emitting events when the state changes.
    */
-  observe(): void;
+  observe(): ValueOrPromise<void>;
 
   /**
    * Stop observing the music player. Remove all listeners.
    */
-  unobserve(): void;
+  unobserve(): ValueOrPromise<void>;
 }

--- a/src/types/Util.ts
+++ b/src/types/Util.ts
@@ -1,0 +1,1 @@
+export type ValueOrPromise<T> = T | Promise<T>;


### PR DESCRIPTION
### Overview

- Implemented the `AmazonMusicObserverEmitter`, which is responsible for watching for when the player state, current song, or queue changes so the mini player can stay up-to-date. There were three general strategies employed to enable this in order of preference:
  - Use Maestro's events to react to pause/play and current time updates
  - Use the Redux store's subscribe method to trigger a comparison method that checks for specific application state changes for everything else except the queue
  - Use a timer for the queue because the queue's state only updates after some other things get triggered that can't easily be listened for
- Updated the no-op event handlers to return undefined because it was causing a `chrome` API handler by having no response.